### PR TITLE
[FEAT] 로그아웃, 회원탈퇴 기능 구현 (closed #5)

### DIFF
--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/controller/MemberController.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/controller/MemberController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,5 +50,13 @@ public class MemberController {
             @RequestBody LogoutRequestDTO logoutRequestDTO
     )  {
         return memberService.logout(memberDetails.getMember(), logoutRequestDTO);
+    }
+
+    @Operation(description = "회원 탈퇴")
+    @DeleteMapping("/withdrawal")
+    public DataResponseDTO<?> withdrawal(HttpServletRequest httpServletRequest, @AuthenticationPrincipal MemberDetails memberDetails) {
+        String accessToken = httpServletRequest.getHeader("Authorization");
+        log.info("accessToken : {}", accessToken);
+        return memberService.withdrawal(memberDetails.getMember(), accessToken);
     }
 }

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/controller/MemberController.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/controller/MemberController.java
@@ -8,11 +8,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.duckdns.omaju.api.dto.auth.MemberDetails;
 import org.duckdns.omaju.api.dto.request.login.LoginRequestDTO;
+import org.duckdns.omaju.api.dto.request.logout.LogoutRequestDTO;
 import org.duckdns.omaju.api.dto.response.DataResponseDTO;
 import org.duckdns.omaju.api.service.jwt.JwtService;
 import org.duckdns.omaju.api.service.member.MemberService;
 import org.duckdns.omaju.core.exeption.RejoinNotAllowedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -37,5 +40,14 @@ public class MemberController {
     @PostMapping("/kakao-login")
     public DataResponseDTO<?> kakaoLogin(@Valid @RequestBody LoginRequestDTO loginRequestDTO) throws IOException, GeneralSecurityException, JsonProcessingException, RejoinNotAllowedException {
         return memberService.kakaoLogin(loginRequestDTO);
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃")
+    @PostMapping("/logout")
+    public DataResponseDTO<?> logout(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestBody LogoutRequestDTO logoutRequestDTO
+    )  {
+        return memberService.logout(memberDetails.getMember(), logoutRequestDTO);
     }
 }

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/dto/request/login/LoginRequestDTO.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/dto/request/login/LoginRequestDTO.java
@@ -7,7 +7,6 @@ import lombok.*;
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginRequestDTO {
-
     @NotNull
     private String accessToken;
 

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/dto/response/member/WithdrawalStatus.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/dto/response/member/WithdrawalStatus.java
@@ -1,0 +1,5 @@
+package org.duckdns.omaju.api.dto.response.member;
+
+public enum WithdrawalStatus {
+    FAIL, KAKAO
+}

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/member/MemberService.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/member/MemberService.java
@@ -15,5 +15,6 @@ import java.security.GeneralSecurityException;
 public interface MemberService {
     DataResponseDTO<?> kakaoLogin(LoginRequestDTO loginRequestDTO) throws GeneralSecurityException, IOException, JsonProcessingException;
     UserDetails loadUserByUsername(String email, Provider provider) throws UsernameNotFoundException;
-    public DataResponseDTO<?> logout(Member member, LogoutRequestDTO logoutReqDto);
+    DataResponseDTO<?> logout(Member member, LogoutRequestDTO logoutReqDto);
+    DataResponseDTO<?> withdrawal(Member member, String accessToken);
 }

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/member/MemberService.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/member/MemberService.java
@@ -2,7 +2,9 @@ package org.duckdns.omaju.api.service.member;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.duckdns.omaju.api.dto.request.login.LoginRequestDTO;
+import org.duckdns.omaju.api.dto.request.logout.LogoutRequestDTO;
 import org.duckdns.omaju.api.dto.response.DataResponseDTO;
+import org.duckdns.omaju.core.entity.member.Member;
 import org.duckdns.omaju.core.type.Provider;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -13,4 +15,5 @@ import java.security.GeneralSecurityException;
 public interface MemberService {
     DataResponseDTO<?> kakaoLogin(LoginRequestDTO loginRequestDTO) throws GeneralSecurityException, IOException, JsonProcessingException;
     UserDetails loadUserByUsername(String email, Provider provider) throws UsernameNotFoundException;
+    public DataResponseDTO<?> logout(Member member, LogoutRequestDTO logoutReqDto);
 }

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/member/MemberServiceImpl.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/member/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import org.duckdns.omaju.api.dto.auth.MemberDetails;
 import org.duckdns.omaju.api.dto.auth.UserDetailsImpl;
 import org.duckdns.omaju.api.dto.auth.UserInfoDTO;
 import org.duckdns.omaju.api.dto.request.login.LoginRequestDTO;
+import org.duckdns.omaju.api.dto.request.logout.LogoutRequestDTO;
 import org.duckdns.omaju.api.dto.response.DataResponseDTO;
 import org.duckdns.omaju.api.dto.response.login.LoginResponseDTO;
 import org.duckdns.omaju.api.service.jwt.JwtService;
@@ -138,8 +139,7 @@ public class MemberServiceImpl implements MemberService {
      * @param memberInfo : 카카오로부터 받은 user info
      * @return Map<String, Object> : member 정보와 기존에 존재하던 사용자인지 아닌지 여부 정보
      */
-    private Map<String, Object> signUpMemberIfNeed(UserInfoDTO memberInfo, LoginRequestDTO loginRequestDTO)
-    {
+    private Map<String, Object> signUpMemberIfNeed(UserInfoDTO memberInfo, LoginRequestDTO loginRequestDTO) {
         Map<String, Object> resMap = new HashMap<>();
         boolean isExist = true;
         Member member = memberRepository.findByEmailAndProvider(memberInfo.getEmail(), memberInfo.getProvider())
@@ -175,8 +175,7 @@ public class MemberServiceImpl implements MemberService {
      * @param member : 회원가입처리가 된 사용자 정보
      * @return authentication : 로그인 인증서
      */
-    private Authentication forceLogin(Member member)
-    {
+    private Authentication forceLogin(Member member) {
         UserDetails userDetails = new UserDetailsImpl(member);
         Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -188,8 +187,7 @@ public class MemberServiceImpl implements MemberService {
      * @param isExist : 기존 사용자 or 신규 사용자 구분 여부
      * @return TokenResDto :
      */
-    private LoginResponseDTO memberAuthenticationInput(Authentication authentication, Boolean isExist) throws JsonProcessingException
-    {
+    private LoginResponseDTO memberAuthenticationInput(Authentication authentication, Boolean isExist) throws JsonProcessingException {
         // response header token 추가
         UserDetailsImpl userDetailsImpl = ((UserDetailsImpl) authentication.getPrincipal());
         String email = userDetailsImpl.getEmail();
@@ -228,5 +226,16 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findByEmailAndProvider(email, provider).orElseThrow
                 (() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
         return new MemberDetails(member);
+    }
+
+    @Override
+    public DataResponseDTO<?> logout(Member member, LogoutRequestDTO logoutReqDto) {
+        setBlackList(member, logoutReqDto.getAccessToken());
+        return DataResponseDTO.builder()
+                .message("로그아웃되었습니다.")
+                .data(true)
+                .statusName(HttpStatus.OK.name())
+                .status(HttpStatus.OK.value())
+                .build();
     }
 }

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/member/MemberServiceImpl.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/member/MemberServiceImpl.java
@@ -12,6 +12,7 @@ import org.duckdns.omaju.api.dto.request.login.LoginRequestDTO;
 import org.duckdns.omaju.api.dto.request.logout.LogoutRequestDTO;
 import org.duckdns.omaju.api.dto.response.DataResponseDTO;
 import org.duckdns.omaju.api.dto.response.login.LoginResponseDTO;
+import org.duckdns.omaju.api.dto.response.member.WithdrawalStatus;
 import org.duckdns.omaju.api.service.jwt.JwtService;
 import org.duckdns.omaju.core.entity.member.Member;
 import org.duckdns.omaju.core.repository.MemberRepository;
@@ -234,6 +235,34 @@ public class MemberServiceImpl implements MemberService {
         return DataResponseDTO.builder()
                 .message("로그아웃되었습니다.")
                 .data(true)
+                .statusName(HttpStatus.OK.name())
+                .status(HttpStatus.OK.value())
+                .build();
+    }
+
+    @Override
+    public DataResponseDTO<?> withdrawal(Member member, String accessToken) {
+        WithdrawalStatus withdrawalStatus = WithdrawalStatus.FAIL;
+
+        if (member.isLeave()) {
+            return DataResponseDTO.builder()
+                    .data(withdrawalStatus.ordinal())
+                    .message("이미 탈퇴한 회원입니다.")
+                    .statusName(HttpStatus.OK.name())
+                    .status(HttpStatus.OK.value())
+                    .build();
+        }
+
+        if (member.getProvider() == Provider.KAKAO)
+            withdrawalStatus = WithdrawalStatus.KAKAO;
+
+        setBlackList(member, accessToken);
+        member.setLeave(true);
+        memberRepository.save(member);
+
+        return DataResponseDTO.builder()
+                .data(withdrawalStatus.ordinal())
+                .message("정상적으로 탈퇴되었습니다.")
                 .statusName(HttpStatus.OK.name())
                 .status(HttpStatus.OK.value())
                 .build();


### PR DESCRIPTION
## 📌 관련 이슈
#5 

<br/>

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 카카오 소셜로그인 기반 서비스 로그아웃 구현
- 카카오 소셜로그인 기반 서비스 회원탈퇴 구현
<br/>

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![image](https://github.com/project-omaju/omaju-backend/assets/68414303/d8fc6cef-f398-4484-87bd-cd0039295f7b)

<br/>

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- 추후 JPA의 .save() 메소드를 사용하지 않는 코드로 수정 필요.
  - https://winterroom.tistory.com/161
  - https://hevton.tistory.com/867
