### PR TITLE
[FEAT] 화면에 보이는 지도 범위에 따른 문화생활 리스트 조회 구현 (closed #46)

### DIFF
--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/controller/CultureController.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/controller/CultureController.java
@@ -21,10 +21,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Slf4j
-@Tag(name = "CulturalEvent", description = "문화행사 관련 API")
+@Tag(name = "CultureEvent", description = "문화행사 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/culture-events")
@@ -82,12 +83,27 @@ public class CultureController {
     })
     @Operation(summary = "페이징한 모든 문화행사 조회", description = "저장된 모든 문화행사 데이터를 조회합니다.")
 
-    @GetMapping("list/paging/{page}/{size}")
-    public DataResponseDTO<List<CultureEventDTO>> getCultureEventPaging(
+    @GetMapping("/list/paging/{page}/{size}")
+    public DataResponseDTO<List<CultureEventDTO>> getCultureEventsPaging(
             @AuthenticationPrincipal MemberDetails memberDetails,
             @Parameter(name = "page", description = "0 이상의 페이지 수") @PathVariable int page,
             @Parameter(name = "size", description = "한 페이지에 할당되는 글 수") @PathVariable int size) {
         Pageable pageable = PageRequest.of(page, size);
         return cultureService.getCultureEventsPaging(pageable, memberDetails.getMember().getId());
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정상적으로 문화행사를 조회한 경우"),
+            @ApiResponse(responseCode = "404", description = "문화행사를 조회하지 못한 경우")
+    })
+    @Operation(summary = "위경도 범위로 문화행사 조회", description = "화면에 보이는 영역 내의 문화행사 데이터를 조회합니다.")
+    @GetMapping("/list/bounds/{southLat}/{northLat}/{westLon}/{eastLon}")
+    public DataResponseDTO<List<CultureEventDTO>> getCultureEventsWithinBounds(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @Parameter(name = "southLat", description = "하단 위도") @PathVariable BigDecimal southLat,
+            @Parameter(name = "northLat", description = "상단 위도") @PathVariable BigDecimal northLat,
+            @Parameter(name = "westLon", description = "좌측 경도") @PathVariable BigDecimal westLon,
+            @Parameter(name = "eastLon", description = "우측 경도") @PathVariable BigDecimal eastLon) {
+        return cultureService.getCultureEventsWithinBounds(southLat, northLat, westLon, eastLon, memberDetails.getMember().getId());
     }
 }

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/controller/CultureLikeController.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/controller/CultureLikeController.java
@@ -48,6 +48,8 @@ public class CultureLikeController {
         return cultureLikeService.getCultureLikesByDate(memberDetails.getMember().getId(), date);
     }
 
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "조회 성공"), @ApiResponse(responseCode = "400", description = "입력 데이터 부적합"), @ApiResponse(responseCode = "401", description = "인증 실패")})
+    @Operation(summary = "특정 달에 포함된 북마크된 문화생활 조회", description = "특정 달에 포함된 북마크된 문화생활 게시글들을 조회합니다.")
     @GetMapping("/month/{month}")
     public DataResponseDTO<Map<LocalDate, Boolean>> getFavoritesByMonth(
             @AuthenticationPrincipal MemberDetails memberDetails,

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/culture/CultureService.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/culture/CultureService.java
@@ -4,7 +4,9 @@ import org.duckdns.omaju.api.dto.culture.CultureEventDTO;
 import org.duckdns.omaju.api.dto.response.DataResponseDTO;
 
 import org.springframework.data.domain.Pageable;
+
 import java.util.List;
+import java.math.BigDecimal;
 
 public interface CultureService {
 
@@ -17,4 +19,6 @@ public interface CultureService {
     DataResponseDTO<CultureEventDTO> getCultureEventByWeather(String weather);
 
     DataResponseDTO<List<CultureEventDTO>> getCultureEventsPaging(Pageable pageable, int memberId);
+
+    DataResponseDTO<List<CultureEventDTO>> getCultureEventsWithinBounds(BigDecimal southLat, BigDecimal northLat, BigDecimal westLon, BigDecimal eastLon, int memberId);
 }

--- a/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/culture/CultureServiceImpl.java
+++ b/omaju-app-api/src/main/java/org/duckdns/omaju/api/service/culture/CultureServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -38,7 +39,8 @@ public class CultureServiceImpl implements CultureService {
         List<CultureEventDTO> eventDTOs = events.stream()
                 .map(event -> {
                     boolean likeStatus = isLikedByMember(event, memberId);
-                    return new CultureEventDTO(event, likeStatus);})
+                    return new CultureEventDTO(event, likeStatus);
+                })
                 .collect(Collectors.toList());
 
         return DataResponseDTO.<List<CultureEventDTO>>builder()
@@ -75,7 +77,8 @@ public class CultureServiceImpl implements CultureService {
         List<CultureEventDTO> eventDTOs = events.stream()
                 .map(event -> {
                     boolean likeStatus = isLikedByMember(event, memberId);
-                    return new CultureEventDTO(event, likeStatus);})
+                    return new CultureEventDTO(event, likeStatus);
+                })
                 .collect(Collectors.toList());
 
         return DataResponseDTO.<List<CultureEventDTO>>builder()
@@ -125,13 +128,32 @@ public class CultureServiceImpl implements CultureService {
         List<CultureEventDTO> eventDTOs = events.stream()
                 .map(event -> {
                     boolean likeStatus = isLikedByMember(event, memberId);
-                    return new CultureEventDTO(event, likeStatus);})
+                    return new CultureEventDTO(event, likeStatus);
+                })
                 .collect(Collectors.toList());
 
         return DataResponseDTO.<List<CultureEventDTO>>builder()
                 .data(eventDTOs)
                 .status(HttpStatus.OK.value())
                 .message("문화생활 페이징 전체 조회 완료")
+                .statusName(HttpStatus.OK.name())
+                .build();
+    }
+
+    @Override
+    public DataResponseDTO<List<CultureEventDTO>> getCultureEventsWithinBounds(BigDecimal southLat, BigDecimal northLat, BigDecimal westLon, BigDecimal eastLon, int memberId) {
+        List<CultureEvent> events = cultureRepository.findAllWithinBounds(southLat, northLat, westLon, eastLon);
+        List<CultureEventDTO> eventDTOs = events.stream()
+                .map(event -> {
+                    boolean likeStatus = isLikedByMember(event, memberId);
+                    return new CultureEventDTO(event, likeStatus);
+                })
+                .collect(Collectors.toList());
+
+        return DataResponseDTO.<List<CultureEventDTO>>builder()
+                .data(eventDTOs)
+                .status(HttpStatus.OK.value())
+                .message("문화생활 범위 내 전체 조회 완료")
                 .statusName(HttpStatus.OK.name())
                 .build();
     }

--- a/omaju-core/src/main/java/org/duckdns/omaju/core/repository/CultureRepository.java
+++ b/omaju-core/src/main/java/org/duckdns/omaju/core/repository/CultureRepository.java
@@ -4,9 +4,11 @@ import org.springframework.data.domain.Page;
 import org.duckdns.omaju.core.entity.culture.CultureEvent;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,4 +24,10 @@ public interface CultureRepository extends JpaRepository<CultureEvent, Integer> 
     List<CultureEvent> findByGenre(String genre);
 
     Page<CultureEvent> findAll(Pageable pageable);
+
+    @Query("SELECT ce FROM CultureEvent ce WHERE ce.lat BETWEEN :southLat AND :northLat AND ce.lon BETWEEN :westLon AND :eastLon")
+    List<CultureEvent> findAllWithinBounds(@Param("southLat") BigDecimal southLat,
+                                           @Param("northLat") BigDecimal northLat,
+                                           @Param("westLon") BigDecimal westLon,
+                                           @Param("eastLon") BigDecimal eastLon);
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #46 
<br/>

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 화면에 보이는 상하좌우 위경도 값 사이에 존재하는 모든 문화생활 글 반환하도록 구현
<br/>

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![스크린샷 2024-07-14 오후 10 19 24](https://github.com/user-attachments/assets/4f934287-fece-4a1e-8a96-50daa0af6f2a)

<br/>

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
